### PR TITLE
feat: add language settings

### DIFF
--- a/cogs/lang.py
+++ b/cogs/lang.py
@@ -1,0 +1,27 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+
+class Language(commands.GroupCog, name="language"):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @app_commands.command(name="set")
+    @app_commands.describe(locale="Locale code to use, e.g. 'en'")
+    async def set_language(self, interaction: discord.Interaction, locale: str):
+        """Set your preferred language"""
+        self.bot.i18n.set_user_lang(interaction.user.id, locale)
+        await interaction.response.send_message(
+            self.bot.i18n.t(locale, "language_set", locale=locale),
+            ephemeral=True,
+        )
+
+    @app_commands.command(name="show")
+    async def show_language(self, interaction: discord.Interaction):
+        """Show your current language"""
+        locale = self.bot.i18n.user_lang.get(str(interaction.user.id), self.bot.i18n.default)
+        await interaction.response.send_message(
+            self.bot.i18n.t(locale, "language_current", locale=locale),
+            ephemeral=True,
+        )

--- a/locales/en.json
+++ b/locales/en.json
@@ -10,5 +10,7 @@
   "no_listings_org": "No listings to display for org",
   "no_order": "No order in this channel. Please select an order to update.",
   "status_updated": "Successfully updated status for the order",
-  "status_updated_specific": "Successfully updated the status to {status} for order '{title}'"
+  "status_updated_specific": "Successfully updated the status to {status} for order '{title}'",
+  "language_set": "Language updated to {locale}",
+  "language_current": "Your current language is {locale}"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -10,5 +10,7 @@
   "no_listings_org": "Немає оголошень для організації",
   "no_order": "У цьому каналі немає замовлення. Виберіть замовлення для оновлення.",
   "status_updated": "Статус замовлення успішно оновлено",
-  "status_updated_specific": "Статус успішно оновлено на {status} для замовлення '{title}'"
+  "status_updated_specific": "Статус успішно оновлено на {status} для замовлення '{title}'",
+  "language_set": "Мову встановлено на {locale}",
+  "language_current": "Ваша поточна мова {locale}"
 }

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from cogs.lookup import Lookup
 from cogs.order import order
 from cogs.registration import Registration, DISCORD_BACKEND_URL
 from cogs.stock import stock
+from cogs.lang import Language
 from util.api_server import create_api
 from util.result import Result
 from util.i18n import I18n
@@ -38,6 +39,7 @@ class SCMarket(Bot):
         await self.add_cog(Lookup(self))
         await self.add_cog(order(self))
         await self.add_cog(stock(self))
+        await self.add_cog(Language(self))
 
         await self.tree.sync()
 


### PR DESCRIPTION
## Summary
- add /language commands to set and show user language
- register language cog
- localize language responses for English and Ukrainian

## Testing
- `python -m py_compile main.py cogs/lang.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68922240d15c8325bcd67cd02ce60300