### PR TITLE
Add user locale command and helper

### DIFF
--- a/cogs/locale.py
+++ b/cogs/locale.py
@@ -1,0 +1,21 @@
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from util.i18n import set_locale
+
+
+class Locale(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @app_commands.command(name="language")
+    @app_commands.describe(code="Locale code, e.g. 'en' or 'uk'")
+    async def language(self, interaction: discord.Interaction, code: str):
+        """Set the preferred language for this user."""
+        set_locale(interaction.user.id, code)
+        await interaction.response.send_message(f"Language set to {code}", ephemeral=True)
+
+
+async def setup(bot):
+    await bot.add_cog(Locale(bot))

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from cogs.lookup import Lookup
 from cogs.order import order
 from cogs.registration import Registration, DISCORD_BACKEND_URL
 from cogs.stock import stock
+from cogs.locale import Locale
 from util.api_server import create_api
 from util.result import Result
 
@@ -37,6 +38,7 @@ class SCMarket(Bot):
         await self.add_cog(Lookup(self))
         await self.add_cog(order(self))
         await self.add_cog(stock(self))
+        await self.add_cog(Locale(self))
 
         await self.tree.sync()
 

--- a/util/i18n.py
+++ b/util/i18n.py
@@ -7,6 +7,10 @@ from typing import Dict
 # This dictionary will hold all loaded translations.
 TRANSLATIONS: Dict[str, Dict[str, str]] = {}
 
+# Path and dictionary for user locale preferences.
+PREFERENCES_PATH = Path(__file__).resolve().parent.parent / "locale_prefs.json"
+LOCALES: Dict[str, str] = {}
+
 
 def load_translations() -> None:
     """Load all JSON translation files from the locales directory."""
@@ -15,6 +19,43 @@ def load_translations() -> None:
     for file in locales_path.glob("*.json"):
         with file.open("r", encoding="utf-8") as f:
             TRANSLATIONS[file.stem] = json.load(f)
+
+
+def load_preferences() -> None:
+    """Load saved user locale preferences from disk."""
+    global LOCALES
+    if PREFERENCES_PATH.exists():
+        with PREFERENCES_PATH.open("r", encoding="utf-8") as f:
+            LOCALES = json.load(f)
+
+
+def save_preferences() -> None:
+    """Persist user locale preferences to disk."""
+    with PREFERENCES_PATH.open("w", encoding="utf-8") as f:
+        json.dump(LOCALES, f)
+
+
+def set_locale(user_id: int, code: str) -> None:
+    """Set the locale preference for ``user_id``."""
+    LOCALES[str(user_id)] = code
+    save_preferences()
+
+
+def get_locale(user_id: int, interaction) -> str:
+    """Return the preferred locale for ``user_id``.
+
+    Checks saved preferences first, then falls back to the locale
+    provided by the interaction or defaults to English.
+    """
+    if str(user_id) in LOCALES:
+        return LOCALES[str(user_id)]
+    if interaction and getattr(interaction, "locale", None):
+        return str(interaction.locale).split("-")[0]
+    return "en"
+
+
+# Load preferences on import so ``get_locale`` can be used immediately.
+load_preferences()
 
 
 def t(key: str, locale: str = "en") -> str:


### PR DESCRIPTION
## Summary
- add `/language` command to store per-user locale preference
- persist locale preferences and provide `get_locale` helper
- load Locale cog during bot startup

## Testing
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6892332404348325aaea9a10612e5a3f