### PR TITLE
Localize view placeholders and button labels

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -68,4 +68,7 @@
   ,
   "locale.set.success": "Language set to {locale}",
   "locale.set.invalid": "Unsupported language: {locale}"
+  ,
+  "views.select_status": "Select status...",
+  "views.update": "Update"
 }

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -68,4 +68,7 @@
   ,
   "locale.set.success": "Мову встановлено на {locale}",
   "locale.set.invalid": "Непідтримувана мова: {locale}"
+  ,
+  "views.select_status": "Виберіть статус...",
+  "views.update": "Оновити"
 }

--- a/util/views.py
+++ b/util/views.py
@@ -3,18 +3,32 @@ from typing import Tuple, List
 
 import discord.ui
 
+from .i18n import t
+
 
 class SelectItem(discord.ui.Select):
-    def __init__(self, choices: List[Tuple[str, str, str]], min_values=1, max_values=1, placeholder='Select status...'):
+    def __init__(
+        self,
+        choices: List[Tuple[str, str, str]],
+        min_values: int = 1,
+        max_values: int = 1,
+        placeholder: str | None = None,
+    ):
         super().__init__(
-            min_values=min_values, max_values=max_values, placeholder=placeholder,
+            min_values=min_values,
+            max_values=max_values,
+            placeholder=placeholder,
             options=[
-                discord.SelectOption(label=label,
-                                     description=description[:97] + "..."[
-                                                                    :100 - len(description)] if description else None,
-                                     value=value)
+                discord.SelectOption(
+                    label=label,
+                    description=description[:97]
+                    + "..."[: 100 - len(description)]
+                    if description
+                    else None,
+                    value=value,
+                )
                 for label, description, value in choices
-            ]
+            ],
         )
 
     async def callback(self, interaction: discord.Interaction):
@@ -26,23 +40,29 @@ class EntrySpec:
     choices: List[Tuple[str, str, str]]
     min_values: int = 1
     max_values: int = 1
-    placeholder: str = 'Select status...'
+    placeholder: str | None = None
 
 
 class UpdateView(discord.ui.View):
-    def __init__(self, interaction, callback: callable, specs: List[EntrySpec]):
+    def __init__(self, interaction, callback: callable, specs: List[EntrySpec], locale: str):
         super().__init__()
         self.interaction = interaction
-        self.selects = []
+        self.selects: List[SelectItem] = []
         for spec in specs:
-            item = SelectItem(spec.choices, spec.min_values, spec.max_values, spec.placeholder)
+            item = SelectItem(
+                spec.choices,
+                spec.min_values,
+                spec.max_values,
+                spec.placeholder or t("views.select_status", locale),
+            )
             self.selects.append(item)
             self.add_item(item)
+        self.submit.label = t("views.update", locale)
         self.callback = callback
 
     async def send(self):
         await self.interaction.response.send_message(view=self, ephemeral=True)
 
-    @discord.ui.button(label='Update')
+    @discord.ui.button()
     async def submit(self, interaction: discord.Interaction, button: discord.ui.Button):
         await self.callback(interaction, *[item.values for item in self.selects])


### PR DESCRIPTION
## Summary
- localize status select placeholder and update button
- add translations for view strings in English and Ukrainian

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68924a7b58a48325a10805c83a20ed25