### PR TITLE
Handle invalid JSON in order status update

### DIFF
--- a/cogs/order.py
+++ b/cogs/order.py
@@ -51,20 +51,26 @@ class order(
     ):
         """Set the new status for the order in the current thread"""
         locale = get_locale(interaction.user.id, interaction)
-        order_payload = json.loads(order)
         if order is None:
             if isinstance(interaction.channel, discord.Thread):
-                response = await internal_post("/threads/order/status",
-                                               json={
-                                                   "status": newstatus,
-                                                   "thread_id": str(interaction.channel.id),
-                                                   "discord_id": str(interaction.user.id)
-                                               },
-                                               session=self.bot.session)
+                response = await internal_post(
+                    "/threads/order/status",
+                    json={
+                        "status": newstatus,
+                        "thread_id": str(interaction.channel.id),
+                        "discord_id": str(interaction.user.id)
+                    },
+                    session=self.bot.session
+                )
             else:
                 await interaction.response.send_message(t("order.no_order", locale))
                 return
         else:
+            try:
+                order_payload = json.loads(order)
+            except json.JSONDecodeError:
+                await interaction.response.send_message(t("order.invalid", locale))
+                return
             response = await internal_post(
                 "/threads/order/status",
                 json={

--- a/locales/en.json
+++ b/locales/en.json
@@ -16,6 +16,7 @@
   "order.no_order": "No order in this channel. Please select an order to update.",
   "order.update_success_with_title": "Successfully updated the status to {status} for order '[{title}](<https://sc-market.space/contract/{order_id}>)'",
   "order.update_success": "Successfully updated status for the order",
+  "order.invalid": "Invalid order data provided.",
   "order.status.fulfilled": "Fulfilled",
   "order.status.in_progress": "In Progress",
   "order.status.cancelled": "Cancelled",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -16,6 +16,7 @@
   "order.no_order": "У цьому каналі немає замовлення. Будь ласка, виберіть замовлення для оновлення.",
   "order.update_success_with_title": "Статус успішно оновлено до {status} для замовлення '[{title}](<https://sc-market.space/contract/{order_id}>)'",
   "order.update_success": "Статус замовлення успішно оновлено",
+  "order.invalid": "Надано недійсні дані замовлення.",
   "order.status.fulfilled": "Виконано",
   "order.status.in_progress": "В процесі",
   "order.status.cancelled": "Скасовано",


### PR DESCRIPTION
## Summary
- avoid decoding `order` when it's not provided
- handle invalid JSON in `update_status`
- add translations for invalid order input

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68925ec10a248325a0619c6ab6a367f3