### PR TITLE
Improve localization for language commands

### DIFF
--- a/cogs/locale.py
+++ b/cogs/locale.py
@@ -62,45 +62,45 @@ class Locale(commands.Cog):
         )
 
     @app_commands.command(
-        name=t("commands.locale.setlanguage.name"),
-        description=t("commands.locale.setlanguage.description"),
+        name=lambda: t("commands.locale.setlanguage.name"),  # "commands.locale.setlanguage.name"
+        description=lambda: t("commands.locale.setlanguage.description"),  # "commands.locale.setlanguage.description"
     )
     @app_commands.describe(
         code=app_commands.locale_str(
-            "Locale code, e.g. 'en' or 'uk'",
-            uk="Код мови, напр. 'en' або 'uk'",
-        )
+            t("commands.locale.setlanguage.code", "en"),
+            **{loc: t("commands.locale.setlanguage.code", loc) for loc in TRANSLATIONS},
+        )  # "commands.locale.setlanguage.code"
     )
     async def setlanguage(self, interaction: discord.Interaction, code: str | None = None):
         """Set the preferred language for this user."""
         await self._set_language(interaction, code)
 
     setlanguage.name_localizations = {
-        "uk": t("commands.locale.setlanguage.name", "uk")
+        loc: t("commands.locale.setlanguage.name", loc) for loc in TRANSLATIONS
     }
     setlanguage.description_localizations = {
-        "uk": t("commands.locale.setlanguage.description", "uk")
+        loc: t("commands.locale.setlanguage.description", loc) for loc in TRANSLATIONS
     }
 
     @app_commands.command(
-        name=t("commands.locale.language.name"),
-        description=t("commands.locale.language.description"),
+        name=lambda: t("commands.locale.language.name"),  # "commands.locale.language.name"
+        description=lambda: t("commands.locale.language.description"),  # "commands.locale.language.description"
     )
     @app_commands.describe(
         code=app_commands.locale_str(
-            "Locale code, e.g. 'en' or 'uk'",
-            uk="Код мови, напр. 'en' або 'uk'",
-        )
+            t("commands.locale.setlanguage.code", "en"),
+            **{loc: t("commands.locale.setlanguage.code", loc) for loc in TRANSLATIONS},
+        )  # "commands.locale.setlanguage.code"
     )
     async def language(self, interaction: discord.Interaction, code: str | None = None):
         """Alias for setlanguage."""
         await self._set_language(interaction, code)
 
     language.name_localizations = {
-        "uk": t("commands.locale.language.name", "uk")
+        loc: t("commands.locale.language.name", loc) for loc in TRANSLATIONS
     }
     language.description_localizations = {
-        "uk": t("commands.locale.language.description", "uk")
+        loc: t("commands.locale.language.description", loc) for loc in TRANSLATIONS
     }
 
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -74,6 +74,7 @@
   "commands.admin.info.description": "Some simple details about the bot",
   "commands.locale.setlanguage.name": "setlanguage",
   "commands.locale.setlanguage.description": "Set the preferred language for this user",
+  "commands.locale.setlanguage.code": "Locale code, e.g. 'en' or 'uk'",
   "commands.locale.language.name": "language",
   "commands.locale.language.description": "Alias for setlanguage",
   "commands.lookup.group.name": "lookup",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -74,6 +74,7 @@
   "commands.admin.info.description": "Деякі прості відомості про бота",
   "commands.locale.setlanguage.name": "встановитимову",
   "commands.locale.setlanguage.description": "Встановити бажану мову для цього користувача",
+  "commands.locale.setlanguage.code": "Код мови, напр. 'en' або 'uk'",
   "commands.locale.language.name": "мова",
   "commands.locale.language.description": "Псевдонім для setlanguage",
   "commands.lookup.group.name": "перегляд",


### PR DESCRIPTION
## Summary
- Localize `setlanguage` and `language` commands with dynamic translations and full localization dictionaries
- Provide multi-locale descriptions for language code parameter
- Add translation key for locale code in English and Ukrainian JSON files

## Testing
- `python -m py_compile cogs/locale.py`
- `python -m json.tool locales/en.json`
- `python -m json.tool locales/uk.json`


------
https://chatgpt.com/codex/tasks/task_e_689263432f9c8325a4f22fa996616d45