### PR TITLE
Localize registration commands and parameters

### DIFF
--- a/cogs/registration.py
+++ b/cogs/registration.py
@@ -8,58 +8,63 @@ from discord import app_commands
 from discord.app_commands import checks
 from discord.ext import commands
 
-from util.i18n import t, get_locale
+from util.i18n import TRANSLATIONS, get_locale, t
 
 DISCORD_BACKEND_URL = os.environ.get("DISCORD_BACKEND_URL", "http://web:8081")
 
 
 class Registration(
     commands.GroupCog,
-    name=t("commands.register.group.name"),
-    description=t("commands.register.group.description"),
+    name=lambda locale: t("commands.register.group.name", locale),  # commands.register.group.name
+    description=lambda locale: t("commands.register.group.description", locale),  # commands.register.group.description
 ):
     def __init__(self, bot):
         self.bot = bot
         self.__cog_app_commands_group__.name_localizations = {
-            "uk": t("commands.register.group.name", "uk")
+            loc: t("commands.register.group.name", loc) for loc in TRANSLATIONS
         }
         self.__cog_app_commands_group__.description_localizations = {
-            "uk": t("commands.register.group.description", "uk")
+            loc: t("commands.register.group.description", loc) for loc in TRANSLATIONS
         }
     channel = app_commands.Group(
-        name=t("commands.register.channel.group.name"),
-        description=t("commands.register.channel.group.description"),
+        name=lambda locale: t("commands.register.channel.group.name", locale),  # commands.register.channel.group.name
+        description=lambda locale: t("commands.register.channel.group.description", locale),  # commands.register.channel.group.description
     )
     channel.name_localizations = {
-        "uk": t("commands.register.channel.group.name", "uk")
+        loc: t("commands.register.channel.group.name", loc) for loc in TRANSLATIONS
     }
     channel.description_localizations = {
-        "uk": t("commands.register.channel.group.description", "uk")
+        loc: t("commands.register.channel.group.description", loc)
+        for loc in TRANSLATIONS
     }
     server = app_commands.Group(
-        name=t("commands.register.server.group.name"),
-        description=t("commands.register.server.group.description"),
+        name=lambda locale: t("commands.register.server.group.name", locale),  # commands.register.server.group.name
+        description=lambda locale: t("commands.register.server.group.description", locale),  # commands.register.server.group.description
     )
     server.name_localizations = {
-        "uk": t("commands.register.server.group.name", "uk")
+        loc: t("commands.register.server.group.name", loc) for loc in TRANSLATIONS
     }
     server.description_localizations = {
-        "uk": t("commands.register.server.group.description", "uk")
+        loc: t("commands.register.server.group.description", loc)
+        for loc in TRANSLATIONS
     }
 
     async def cog_app_command_error(self, interaction: discord.Interaction, error):
         await interaction.response.send_message(str(error))
 
     @channel.command(
-        name=t("commands.register.channel.contractor.name"),
-        description=t("commands.register.channel.contractor.description"),
+        name=lambda locale: t("commands.register.channel.contractor.name", locale),  # commands.register.channel.contractor.name
+        description=lambda locale: t("commands.register.channel.contractor.description", locale),  # commands.register.channel.contractor.description
     )
     @checks.has_permissions(administrator=True)
     @app_commands.describe(
         name=app_commands.locale_str(
-            "The name of the contractor",
-            uk="Ім'я підрядника",
-        )
+            t("commands.register.contractor.param.name", "en"),
+            **{
+                loc: t("commands.register.contractor.param.name", loc)
+                for loc in TRANSLATIONS
+            },
+        )  # commands.register.contractor.param.name
     )
     async def contractor_channel(
             self, interaction: discord.Interaction,
@@ -69,15 +74,17 @@ class Registration(
         await self.register(interaction, "channel", "contractor", name)
 
     contractor_channel.name_localizations = {
-        "uk": t("commands.register.channel.contractor.name", "uk")
+        loc: t("commands.register.channel.contractor.name", loc)
+        for loc in TRANSLATIONS
     }
     contractor_channel.description_localizations = {
-        "uk": t("commands.register.channel.contractor.description", "uk")
+        loc: t("commands.register.channel.contractor.description", loc)
+        for loc in TRANSLATIONS
     }
 
     @channel.command(
-        name=t("commands.register.channel.user.name"),
-        description=t("commands.register.channel.user.description"),
+        name=lambda locale: t("commands.register.channel.user.name", locale),  # commands.register.channel.user.name
+        description=lambda locale: t("commands.register.channel.user.description", locale),  # commands.register.channel.user.description
     )
     @checks.has_permissions(administrator=True)
     async def user_channel(
@@ -87,22 +94,26 @@ class Registration(
         await self.register(interaction, "channel", "user")
 
     user_channel.name_localizations = {
-        "uk": t("commands.register.channel.user.name", "uk")
+        loc: t("commands.register.channel.user.name", loc) for loc in TRANSLATIONS
     }
     user_channel.description_localizations = {
-        "uk": t("commands.register.channel.user.description", "uk")
+        loc: t("commands.register.channel.user.description", loc)
+        for loc in TRANSLATIONS
     }
 
     @server.command(
-        name=t("commands.register.server.contractor.name"),
-        description=t("commands.register.server.contractor.description"),
+        name=lambda locale: t("commands.register.server.contractor.name", locale),  # commands.register.server.contractor.name
+        description=lambda locale: t("commands.register.server.contractor.description", locale),  # commands.register.server.contractor.description
     )
     @checks.has_permissions(administrator=True)
     @app_commands.describe(
         name=app_commands.locale_str(
-            "The name of the contractor",
-            uk="Ім'я підрядника",
-        )
+            t("commands.register.contractor.param.name", "en"),
+            **{
+                loc: t("commands.register.contractor.param.name", loc)
+                for loc in TRANSLATIONS
+            },
+        )  # commands.register.contractor.param.name
     )
     async def contractor_server(
             self, interaction: discord.Interaction,
@@ -112,15 +123,17 @@ class Registration(
         await self.register(interaction, "server", "contractor", name)
 
     contractor_server.name_localizations = {
-        "uk": t("commands.register.server.contractor.name", "uk")
+        loc: t("commands.register.server.contractor.name", loc)
+        for loc in TRANSLATIONS
     }
     contractor_server.description_localizations = {
-        "uk": t("commands.register.server.contractor.description", "uk")
+        loc: t("commands.register.server.contractor.description", loc)
+        for loc in TRANSLATIONS
     }
 
     @server.command(
-        name=t("commands.register.server.user.name"),
-        description=t("commands.register.server.user.description"),
+        name=lambda locale: t("commands.register.server.user.name", locale),  # commands.register.server.user.name
+        description=lambda locale: t("commands.register.server.user.description", locale),  # commands.register.server.user.description
     )
     @checks.has_permissions(administrator=True)
     async def user_server(
@@ -130,10 +143,11 @@ class Registration(
         await self.register(interaction, "server", "user")
 
     user_server.name_localizations = {
-        "uk": t("commands.register.server.user.name", "uk")
+        loc: t("commands.register.server.user.name", loc) for loc in TRANSLATIONS
     }
     user_server.description_localizations = {
-        "uk": t("commands.register.server.user.description", "uk")
+        loc: t("commands.register.server.user.description", loc)
+        for loc in TRANSLATIONS
     }
 
     @staticmethod

--- a/locales/en.json
+++ b/locales/en.json
@@ -114,6 +114,7 @@
   "commands.register.server.contractor.description": "Register a server as the official server for your contractor",
   "commands.register.server.user.name": "user",
   "commands.register.server.user.description": "Register a server as the official server for your user",
+  "commands.register.contractor.param.name": "The name of the contractor",
   "commands.stock.group.name": "stock",
   "commands.stock.group.description": "Manage market listing stock",
   "commands.stock.set.name": "set",

--- a/locales/uk.json
+++ b/locales/uk.json
@@ -114,6 +114,7 @@
   "commands.register.server.contractor.description": "Зареєструвати сервер як офіційний сервер вашого підрядника",
   "commands.register.server.user.name": "користувач",
   "commands.register.server.user.description": "Зареєструвати сервер як офіційний сервер вашого користувача",
+  "commands.register.contractor.param.name": "Ім'я підрядника",
   "commands.stock.group.name": "запас",
   "commands.stock.group.description": "Керування запасами оголошень",
   "commands.stock.set.name": "встановити",


### PR DESCRIPTION
## Summary
- Localize all registration groups and subcommands using dynamic translation functions
- Provide locale-aware parameter descriptions for contractor registration
- Add missing translation entries for contractor name parameter

## Testing
- `python -m py_compile cogs/registration.py locales/en.json locales/uk.json`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689267f778708325a9d3541b4508be67