### PR TITLE
Use English fallback strings for admin info command

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -12,8 +12,8 @@ class Admin(commands.Cog):
         self.bot = bot
 
     @app_commands.command(
-        name=lambda locale: t("commands.admin.info.name", locale),  # "commands.admin.info.name"
-        description=lambda locale: t("commands.admin.info.description", locale),  # "commands.admin.info.description"
+        name=t("commands.admin.info.name", "en"),  # "commands.admin.info.name"
+        description=t("commands.admin.info.description", "en"),  # "commands.admin.info.description"
     )
     async def info(self, interaction: discord.Interaction):
         """Some simple details about the bot."""


### PR DESCRIPTION
## Summary
- Use `t` to provide English defaults for the admin info command's name and description
- Keep name and description localization dictionaries for all supported languages

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689270e58aec8325a93db333f6f25823