### PR TITLE
Cast locale to string before processing

### DIFF
--- a/tests/test_localization.py
+++ b/tests/test_localization.py
@@ -16,6 +16,11 @@ class Ctx:
         self.locale = locale
 
 
+class FakeLocale:
+    def __str__(self):
+        return "uk"
+
+
 def flatten(d, prefix=""):
     keys = set()
     for k, v in d.items():
@@ -28,6 +33,11 @@ def flatten(d, prefix=""):
 
 def test_get_locale_preference_interaction():
     ctx = Ctx(interaction=Dummy("uk"))
+    assert get_locale(ctx) == "uk"
+
+
+def test_get_locale_non_string():
+    ctx = Ctx(interaction=Dummy(FakeLocale()))
     assert get_locale(ctx) == "uk"
 
 

--- a/util/i18n.py
+++ b/util/i18n.py
@@ -8,11 +8,11 @@ def get_locale(ctx) -> str:
     """Return the locale for the given interaction/ctx."""
     locale = None
     if getattr(ctx, 'interaction', None) and getattr(ctx.interaction, 'locale', None):
-        locale = ctx.interaction.locale
+        locale = str(ctx.interaction.locale)
     elif getattr(ctx, 'author', None) and getattr(ctx.author, 'locale', None):
-        locale = ctx.author.locale
+        locale = str(ctx.author.locale)
     elif getattr(ctx, 'locale', None):
-        locale = ctx.locale
+        locale = str(ctx.locale)
     if locale:
         locale = locale.split('-')[0]
     if not locale or not (LOCALE_DIR / f"{locale}.json").exists():


### PR DESCRIPTION
## Summary
- Ensure locale attributes are cast to `str` before splitting or further use
- Add test validating `get_locale` with non-string locale

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893a285a2a48325b1911031ecf20119