### PR TITLE
Refactor to JSON-based i18n without Discord command localizations

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -4,7 +4,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from util.i18n import get_locale, t, cmd
+from util.i18n import tr, cmd
 
 
 class Admin(commands.Cog):
@@ -13,14 +13,13 @@ class Admin(commands.Cog):
 
     @app_commands.command(**cmd('info'))
     async def info(self, interaction: discord.Interaction):
-        locale = get_locale(interaction)
         me = self.bot.user if not interaction.guild else interaction.guild.me
         appinfo = await self.bot.application_info()
         embed = discord.Embed(color=randint(0, 0xFFFFFF))
         embed.set_author(name=me.display_name, icon_url=appinfo.owner.display_avatar.url,
                          url="https://sc-market.space")
-        embed.add_field(name=t('info.author', locale), value='henry232323')
-        embed.add_field(name=t('info.servers', locale), value=t('info.server_count', locale, count=len(self.bot.guilds)))
-        embed.set_footer(text=t('info.footer', locale), icon_url='http://i.imgur.com/5BFecvA.png')
+        embed.add_field(name=tr(interaction, 'info.author'), value='henry232323')
+        embed.add_field(name=tr(interaction, 'info.servers'), value=tr(interaction, 'info.server_count', count=len(self.bot.guilds)))
+        embed.set_footer(text=tr(interaction, 'info.footer'), icon_url='http://i.imgur.com/5BFecvA.png')
         embed.set_thumbnail(url=self.bot.user.display_avatar.url)
         await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/cogs/lookup.py
+++ b/cogs/lookup.py
@@ -8,7 +8,7 @@ from discord.ext.paginators.button_paginator import ButtonPaginator
 from util.fetch import public_fetch, search_users, search_orgs
 from util.listings import create_market_embed, categories, sorting_methods, sale_types, create_market_embed_individual, \
     display_listings_compact
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import get_locale, tr, cmd, option
 
 
 class Lookup(commands.Cog):
@@ -64,7 +64,7 @@ class Lookup(commands.Cog):
         locale = get_locale(interaction)
         embeds = [create_market_embed(item, locale) for item in result['listings'] if item['listing']['quantity_available']]
         if not embeds:
-            await interaction.response.send_message(t('search.no_results', locale))
+            await interaction.response.send_message(tr(interaction, 'search.no_results'))
 
         paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
         await paginator.send(interaction)
@@ -85,8 +85,7 @@ class Lookup(commands.Cog):
                 session=self.bot.session,
             )
         except:
-            locale = get_locale(interaction)
-            await interaction.response.send_message(t('lookup.invalid_user', locale))
+            await interaction.response.send_message(tr(interaction, 'lookup.invalid_user'))
             return
 
         if compact:
@@ -97,7 +96,7 @@ class Lookup(commands.Cog):
                       item['listing']['quantity_available']]
 
             if not embeds:
-                await interaction.response.send_message(t('lookup.no_listings', locale))
+                await interaction.response.send_message(tr(interaction, 'lookup.no_listings'))
                 return
 
             paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
@@ -117,8 +116,7 @@ class Lookup(commands.Cog):
                 session=self.bot.session,
             )
         except:
-            locale = get_locale(interaction)
-            await interaction.response.send_message(t('lookup.invalid_org', locale))
+            await interaction.response.send_message(tr(interaction, 'lookup.invalid_org'))
             return
 
         if compact:
@@ -129,7 +127,7 @@ class Lookup(commands.Cog):
                       item['listing']['quantity_available']]
 
             if not embeds:
-                await interaction.response.send_message(t('lookup.no_org_listings', locale))
+                await interaction.response.send_message(tr(interaction, 'lookup.no_org_listings'))
                 return
 
             paginator = ButtonPaginator(embeds, author_id=interaction.user.id)

--- a/cogs/order.py
+++ b/cogs/order.py
@@ -8,7 +8,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from util.fetch import internal_post, get_user_orders
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import tr, cmd, option
 
 
 class order(commands.GroupCog):
@@ -41,8 +41,7 @@ class order(commands.GroupCog):
                                                },
                                                session=self.bot.session)
             else:
-                locale = get_locale(interaction)
-                await interaction.response.send_message(t('order.no_order', locale))
+                await interaction.response.send_message(tr(interaction, 'order.no_order'))
                 return
         else:
             response = await internal_post(
@@ -55,16 +54,15 @@ class order(commands.GroupCog):
                 session=self.bot.session
             )
 
-        locale = get_locale(interaction)
         if response.get("error"):
             await interaction.response.send_message(response['error'])
         else:
             if order:
                 await interaction.response.send_message(
-                    t('order.success_specific', locale, status=newstatus, title=order_payload['t'])
+                    tr(interaction, 'order.success_specific', status=newstatus, title=order_payload['t'])
                 )
             else:
-                await interaction.response.send_message(t('order.success', locale))
+                await interaction.response.send_message(tr(interaction, 'order.success'))
 
     @update_status.autocomplete('order')
     async def update_status_order_autocomplete(

--- a/cogs/registration.py
+++ b/cogs/registration.py
@@ -7,7 +7,7 @@ import discord
 from discord import app_commands
 from discord.app_commands import checks
 from discord.ext import commands
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import tr, cmd, option
 
 DISCORD_BACKEND_URL = os.environ.get("DISCORD_BACKEND_URL", "http://web:8081")
 
@@ -76,11 +76,9 @@ class Registration(commands.GroupCog):
                 except Exception as e:
                     traceback.print_exc()
                     print(text)
-                    locale = get_locale(interaction)
-                    return await interaction.response.send_message(t('registration.unexpected', locale), ephemeral=True)
+                    return await interaction.response.send_message(tr(interaction, 'registration.unexpected'), ephemeral=True)
 
-        locale = get_locale(interaction)
         if resp.ok:
-            await interaction.response.send_message(t('registration.success', locale, type=type, entity=entity), ephemeral=True)
+            await interaction.response.send_message(tr(interaction, 'registration.success', type=type, entity=entity), ephemeral=True)
         else:
-            await interaction.response.send_message(t('registration.fail', locale, error=result.get('error')), ephemeral=True)
+            await interaction.response.send_message(tr(interaction, 'registration.fail', error=result.get('error')), ephemeral=True)

--- a/cogs/stock.py
+++ b/cogs/stock.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 
 from util.fetch import internal_post, get_user_listings, get_user_orgs, get_org_listings
 from util.listings import display_listings_compact
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import tr, cmd, option
 
 
 class stock(commands.GroupCog):
@@ -64,7 +64,6 @@ class stock(commands.GroupCog):
             json=payload,
             session=self.bot.session
         )
-        locale = get_locale(interaction)
         if response.get("error"):
             await interaction.response.send_message(response['error'])
         else:
@@ -77,7 +76,7 @@ class stock(commands.GroupCog):
                 newquantity = quantity
 
             await interaction.response.send_message(
-                t('stock.stock_set', locale, title=listing_payload['t'], old=listing_payload['q'], new=newquantity)
+                tr(interaction, 'stock.stock_set', title=listing_payload['t'], old=listing_payload['q'], new=newquantity)
             )
 
     @app_commands.command(**cmd('stock.view'))
@@ -95,8 +94,7 @@ class stock(commands.GroupCog):
             listings = await get_user_listings(interaction.user.id, session=self.bot.session)
 
         if not listings:
-            locale = get_locale(interaction)
-            await interaction.response.send_message(t('stock.no_listings', locale), ephemeral=True)
+            await interaction.response.send_message(tr(interaction, 'stock.no_listings'), ephemeral=True)
             return
 
         await display_listings_compact(interaction, listings)

--- a/util/i18n.py
+++ b/util/i18n.py
@@ -6,6 +6,7 @@ from discord import app_commands
 
 LOCALE_DIR = Path(__file__).resolve().parent.parent / 'locale'
 
+
 def get_locale(ctx) -> str:
     """Return the locale for the given interaction/ctx."""
     locale = None
@@ -21,6 +22,7 @@ def get_locale(ctx) -> str:
         return 'en'
     return locale
 
+
 @lru_cache(maxsize=None)
 def _load(locale: str) -> dict:
     path = LOCALE_DIR / f"{locale}.json"
@@ -28,6 +30,7 @@ def _load(locale: str) -> dict:
         return _load('en')
     with path.open('r', encoding='utf-8') as f:
         return json.load(f)
+
 
 def t(key: str, locale: str, **kwargs) -> str:
     data = _load(locale)
@@ -38,61 +41,34 @@ def t(key: str, locale: str, **kwargs) -> str:
             return data.format(**kwargs)
         except Exception:
             return data
-    # fallback
     if locale != 'en':
         return t(key, 'en', **kwargs)
     return key
 
 
-def _lookup(locale: str, key: str):
-    """Return raw translation value for the given locale and key."""
-    data = _load(locale)
-    for part in key.split('.'):
-        if isinstance(data, dict):
-            data = data.get(part)
-        else:
-            return None
-    return data if isinstance(data, str) else None
-
-
-def get_localizations(key: str) -> dict:
-    """Return mapping of locale->translation for the given key.
-
-    Falls back to English if a specific locale does not provide the key.
-    """
-    localizations = {}
-    for path in LOCALE_DIR.glob('*.json'):
-        locale = path.stem
-        value = _lookup(locale, key)
-        if value:
-            localizations[locale] = value
-    if 'en' not in localizations:
-        value = _lookup('en', key)
-        if value:
-            localizations['en'] = value
-    return localizations
+def tr(ctx, key: str, **kwargs) -> str:
+    """Translate *key* using the locale derived from *ctx*."""
+    return t(key, get_locale(ctx), **kwargs)
 
 
 def cmd(key: str) -> dict:
-    """Return parameters for a localized command/group."""
-    name_loc = get_localizations(f'commands.{key}.name')
-    desc_loc = get_localizations(f'commands.{key}.description')
-    return dict(
-        name=name_loc.get('en', key.split('.')[-1]),
-        description=desc_loc.get('en', ''),
-        name_localizations=name_loc,
-        description_localizations=desc_loc,
-    )
+    """Return English name/description for a command or group."""
+    name = t(f'commands.{key}.name', 'en')
+    desc = t(f'commands.{key}.description', 'en')
+    if name == f'commands.{key}.name':
+        name = key.split('.')[-1]
+    if desc == f'commands.{key}.description':
+        desc = ''
+    return dict(name=name, description=desc)
 
 
 def option(command_key: str, option_name: str, default=None):
-    """Return app_commands.Param configured with localizations."""
-    name_loc = get_localizations(f'commands.{command_key}.options.{option_name}.name')
-    desc_loc = get_localizations(f'commands.{command_key}.options.{option_name}.description')
-    return app_commands.Param(
-        default,
-        name=name_loc.get('en', option_name),
-        description=desc_loc.get('en', ''),
-        name_localizations=name_loc,
-        description_localizations=desc_loc,
-    )
+    """Return app_commands.Param using English strings from locale files."""
+    name = t(f'commands.{command_key}.options.{option_name}.name', 'en')
+    desc = t(f'commands.{command_key}.options.{option_name}.description', 'en')
+    if name == f'commands.{command_key}.options.{option_name}.name':
+        name = option_name
+    if desc == f'commands.{command_key}.options.{option_name}.description':
+        desc = ''
+    return app_commands.Param(default, name=name, description=desc)
+


### PR DESCRIPTION
## Summary
- drop `name_localizations`/`description_localizations` usage and rely on JSON-based i18n
- add `tr` helper for context-aware translations
- update cogs to use new helper and English-only command metadata

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b139b3d4832598f683b183ebf534