### PR TITLE
Refactor to JSON-based i18n without Discord command localizations

### DIFF
--- a/cogs/admin.py
+++ b/cogs/admin.py
@@ -4,7 +4,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from util.i18n import get_locale, t, cmd
+from util.i18n import tr, cmd
 
 
 class Admin(commands.Cog):
@@ -13,14 +13,13 @@ class Admin(commands.Cog):
 
     @app_commands.command(**cmd('info'))
     async def info(self, interaction: discord.Interaction):
-        locale = get_locale(interaction)
         me = self.bot.user if not interaction.guild else interaction.guild.me
         appinfo = await self.bot.application_info()
         embed = discord.Embed(color=randint(0, 0xFFFFFF))
         embed.set_author(name=me.display_name, icon_url=appinfo.owner.display_avatar.url,
                          url="https://sc-market.space")
-        embed.add_field(name=t('info.author', locale), value='henry232323')
-        embed.add_field(name=t('info.servers', locale), value=t('info.server_count', locale, count=len(self.bot.guilds)))
-        embed.set_footer(text=t('info.footer', locale), icon_url='http://i.imgur.com/5BFecvA.png')
+        embed.add_field(name=tr(interaction, 'info.author'), value='henry232323')
+        embed.add_field(name=tr(interaction, 'info.servers'), value=tr(interaction, 'info.server_count', count=len(self.bot.guilds)))
+        embed.set_footer(text=tr(interaction, 'info.footer'), icon_url='http://i.imgur.com/5BFecvA.png')
         embed.set_thumbnail(url=self.bot.user.display_avatar.url)
         await interaction.response.send_message(embed=embed, ephemeral=True)

--- a/cogs/lookup.py
+++ b/cogs/lookup.py
@@ -8,7 +8,7 @@ from discord.ext.paginators.button_paginator import ButtonPaginator
 from util.fetch import public_fetch, search_users, search_orgs
 from util.listings import create_market_embed, categories, sorting_methods, sale_types, create_market_embed_individual, \
     display_listings_compact
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import get_locale, tr, cmd, option
 
 
 class Lookup(commands.Cog):
@@ -27,16 +27,25 @@ class Lookup(commands.Cog):
             app_commands.Choice(name=item, value=item.lower()) for item in sale_types
         ],
     )
+    @app_commands.describe(
+        query=option('search', 'query'),
+        category=option('search', 'category'),
+        sorting=option('search', 'sorting'),
+        sale_type=option('search', 'sale_type'),
+        quantity_available=option('search', 'quantity_available'),
+        min_cost=option('search', 'min_cost'),
+        max_cost=option('search', 'max_cost'),
+    )
     async def search(
             self,
             interaction: discord.Interaction,
-            query: str = option('search', 'query'),
-            category: app_commands.Choice[str] = option('search', 'category', ''),
-            sorting: app_commands.Choice[str] = option('search', 'sorting', 'activity'),
-            sale_type: app_commands.Choice[str] = option('search', 'sale_type', ''),
-            quantity_available: int = option('search', 'quantity_available', 1),
-            min_cost: int = option('search', 'min_cost', 0),
-            max_cost: int = option('search', 'max_cost', 0),
+            query: str,
+            category: str = '',
+            sorting: str = 'activity',
+            sale_type: str = '',
+            quantity_available: int = 1,
+            min_cost: int = 0,
+            max_cost: int = 0,
     ):
         """Search the site market listings"""
         params = {
@@ -64,7 +73,7 @@ class Lookup(commands.Cog):
         locale = get_locale(interaction)
         embeds = [create_market_embed(item, locale) for item in result['listings'] if item['listing']['quantity_available']]
         if not embeds:
-            await interaction.response.send_message(t('search.no_results', locale))
+            await interaction.response.send_message(tr(interaction, 'search.no_results'))
 
         paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
         await paginator.send(interaction)
@@ -72,11 +81,12 @@ class Lookup(commands.Cog):
     lookup = app_commands.Group(**cmd('lookup'))
 
     @lookup.command(**cmd('lookup.user'))
+    @app_commands.describe(handle=option('lookup.user', 'handle'), compact=option('lookup.user', 'compact'))
     async def user_search(
             self,
             interaction: discord.Interaction,
-            handle: str = option('lookup.user', 'handle'),
-            compact: bool = option('lookup.user', 'compact', False),
+            handle: str,
+            compact: bool = False,
     ):
         """Lookup the market listings for a user"""
         try:
@@ -85,8 +95,7 @@ class Lookup(commands.Cog):
                 session=self.bot.session,
             )
         except:
-            locale = get_locale(interaction)
-            await interaction.response.send_message(t('lookup.invalid_user', locale))
+            await interaction.response.send_message(tr(interaction, 'lookup.invalid_user'))
             return
 
         if compact:
@@ -97,18 +106,19 @@ class Lookup(commands.Cog):
                       item['listing']['quantity_available']]
 
             if not embeds:
-                await interaction.response.send_message(t('lookup.no_listings', locale))
+                await interaction.response.send_message(tr(interaction, 'lookup.no_listings'))
                 return
 
             paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
             await paginator.send(interaction)
 
     @lookup.command(**cmd('lookup.org'))
+    @app_commands.describe(spectrum_id=option('lookup.org', 'spectrum_id'), compact=option('lookup.org', 'compact'))
     async def org_search(
             self,
             interaction: discord.Interaction,
-            spectrum_id: str = option('lookup.org', 'spectrum_id'),
-            compact: bool = option('lookup.org', 'compact', False),
+            spectrum_id: str,
+            compact: bool = False,
     ):
         """Lookup the market listings for an org"""
         try:
@@ -117,8 +127,7 @@ class Lookup(commands.Cog):
                 session=self.bot.session,
             )
         except:
-            locale = get_locale(interaction)
-            await interaction.response.send_message(t('lookup.invalid_org', locale))
+            await interaction.response.send_message(tr(interaction, 'lookup.invalid_org'))
             return
 
         if compact:
@@ -129,7 +138,7 @@ class Lookup(commands.Cog):
                       item['listing']['quantity_available']]
 
             if not embeds:
-                await interaction.response.send_message(t('lookup.no_org_listings', locale))
+                await interaction.response.send_message(tr(interaction, 'lookup.no_org_listings'))
                 return
 
             paginator = ButtonPaginator(embeds, author_id=interaction.user.id)

--- a/cogs/registration.py
+++ b/cogs/registration.py
@@ -7,7 +7,7 @@ import discord
 from discord import app_commands
 from discord.app_commands import checks
 from discord.ext import commands
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import tr, cmd, option
 
 DISCORD_BACKEND_URL = os.environ.get("DISCORD_BACKEND_URL", "http://web:8081")
 
@@ -25,9 +25,10 @@ class Registration(commands.GroupCog):
 
     @channel.command(**cmd('register.channel.contractor'))
     @checks.has_permissions(administrator=True)
+    @app_commands.describe(name=option('register.channel.contractor', 'name'))
     async def contractor_channel(
             self, interaction: discord.Interaction,
-            name: str = option('register.channel.contractor', 'name')
+            name: str
     ):
         """Register a channel as the channel that will house threads for order fulfillment for your contractor. Make sure the bot has permission to see the channel and make private threads there."""
         await self.register(interaction, "channel", "contractor", name)
@@ -42,9 +43,10 @@ class Registration(commands.GroupCog):
 
     @server.command(**cmd('register.server.contractor'))
     @checks.has_permissions(administrator=True)
+    @app_commands.describe(name=option('register.server.contractor', 'name'))
     async def contractor_server(
             self, interaction: discord.Interaction,
-            name: str = option('register.server.contractor', 'name')
+            name: str
     ):
         """Register a server as the official server for order fulfillment for your contractor."""
         await self.register(interaction, "server", "contractor", name)
@@ -76,11 +78,9 @@ class Registration(commands.GroupCog):
                 except Exception as e:
                     traceback.print_exc()
                     print(text)
-                    locale = get_locale(interaction)
-                    return await interaction.response.send_message(t('registration.unexpected', locale), ephemeral=True)
+                    return await interaction.response.send_message(tr(interaction, 'registration.unexpected'), ephemeral=True)
 
-        locale = get_locale(interaction)
         if resp.ok:
-            await interaction.response.send_message(t('registration.success', locale, type=type, entity=entity), ephemeral=True)
+            await interaction.response.send_message(tr(interaction, 'registration.success', type=type, entity=entity), ephemeral=True)
         else:
-            await interaction.response.send_message(t('registration.fail', locale, error=result.get('error')), ephemeral=True)
+            await interaction.response.send_message(tr(interaction, 'registration.fail', error=result.get('error')), ephemeral=True)

--- a/cogs/stock.py
+++ b/cogs/stock.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 
 from util.fetch import internal_post, get_user_listings, get_user_orgs, get_org_listings
 from util.listings import display_listings_compact
-from util.i18n import get_locale, t, cmd, option
+from util.i18n import tr, cmd, option
 
 
 class stock(commands.GroupCog):
@@ -18,34 +18,49 @@ class stock(commands.GroupCog):
         self.bot = bot
 
     @app_commands.command(**cmd('stock.set'))
+    @app_commands.describe(
+        owner=option('stock.set', 'owner'),
+        listing=option('stock.set', 'listing'),
+        quantity=option('stock.set', 'quantity'),
+    )
     async def set_stock(
             self,
             interaction: discord.Interaction,
-            owner: str = option('stock.set', 'owner'),
-            listing: str = option('stock.set', 'listing'),
-            quantity: int = option('stock.set', 'quantity'),
+            owner: str,
+            listing: str,
+            quantity: int,
     ):
         """Set the stock quantity for a given market listing"""
         await self.handle_stock_change(interaction, 'set', owner, listing, quantity)
 
     @app_commands.command(**cmd('stock.add'))
+    @app_commands.describe(
+        owner=option('stock.add', 'owner'),
+        listing=option('stock.add', 'listing'),
+        quantity=option('stock.add', 'quantity'),
+    )
     async def add_stock(
             self,
             interaction: discord.Interaction,
-            owner: str = option('stock.add', 'owner'),
-            listing: str = option('stock.add', 'listing'),
-            quantity: int = option('stock.add', 'quantity'),
+            owner: str,
+            listing: str,
+            quantity: int,
     ):
         """Add to the stock quantity for a given market listing"""
         await self.handle_stock_change(interaction, 'add', owner, listing, quantity)
 
     @app_commands.command(**cmd('stock.sub'))
+    @app_commands.describe(
+        owner=option('stock.sub', 'owner'),
+        listing=option('stock.sub', 'listing'),
+        quantity=option('stock.sub', 'quantity'),
+    )
     async def sub_stock(
             self,
             interaction: discord.Interaction,
-            owner: str = option('stock.sub', 'owner'),
-            listing: str = option('stock.sub', 'listing'),
-            quantity: int = option('stock.sub', 'quantity'),
+            owner: str,
+            listing: str,
+            quantity: int,
     ):
         """Subtract from the stock quantity for a given market listing"""
         await self.handle_stock_change(interaction, 'sub', owner, listing, quantity)
@@ -64,7 +79,6 @@ class stock(commands.GroupCog):
             json=payload,
             session=self.bot.session
         )
-        locale = get_locale(interaction)
         if response.get("error"):
             await interaction.response.send_message(response['error'])
         else:
@@ -77,14 +91,15 @@ class stock(commands.GroupCog):
                 newquantity = quantity
 
             await interaction.response.send_message(
-                t('stock.stock_set', locale, title=listing_payload['t'], old=listing_payload['q'], new=newquantity)
+                tr(interaction, 'stock.stock_set', title=listing_payload['t'], old=listing_payload['q'], new=newquantity)
             )
 
     @app_commands.command(**cmd('stock.view'))
+    @app_commands.describe(owner=option('stock.view', 'owner'))
     async def view_stock(
             self,
             interaction: discord.Interaction,
-            owner: str = option('stock.view', 'owner', None),
+            owner: str = None,
     ):
         """Set the stock quantity for a given market listing"""
         if owner and interaction.namespace.owner != "_ME":
@@ -95,8 +110,7 @@ class stock(commands.GroupCog):
             listings = await get_user_listings(interaction.user.id, session=self.bot.session)
 
         if not listings:
-            locale = get_locale(interaction)
-            await interaction.response.send_message(t('stock.no_listings', locale), ephemeral=True)
+            await interaction.response.send_message(tr(interaction, 'stock.no_listings'), ephemeral=True)
             return
 
         await display_listings_compact(interaction, listings)

--- a/util/i18n.py
+++ b/util/i18n.py
@@ -2,9 +2,8 @@ import json
 from pathlib import Path
 from functools import lru_cache
 
-from discord import app_commands
-
 LOCALE_DIR = Path(__file__).resolve().parent.parent / 'locale'
+
 
 def get_locale(ctx) -> str:
     """Return the locale for the given interaction/ctx."""
@@ -21,6 +20,7 @@ def get_locale(ctx) -> str:
         return 'en'
     return locale
 
+
 @lru_cache(maxsize=None)
 def _load(locale: str) -> dict:
     path = LOCALE_DIR / f"{locale}.json"
@@ -28,6 +28,7 @@ def _load(locale: str) -> dict:
         return _load('en')
     with path.open('r', encoding='utf-8') as f:
         return json.load(f)
+
 
 def t(key: str, locale: str, **kwargs) -> str:
     data = _load(locale)
@@ -38,61 +39,37 @@ def t(key: str, locale: str, **kwargs) -> str:
             return data.format(**kwargs)
         except Exception:
             return data
-    # fallback
     if locale != 'en':
         return t(key, 'en', **kwargs)
     return key
 
 
-def _lookup(locale: str, key: str):
-    """Return raw translation value for the given locale and key."""
-    data = _load(locale)
-    for part in key.split('.'):
-        if isinstance(data, dict):
-            data = data.get(part)
-        else:
-            return None
-    return data if isinstance(data, str) else None
-
-
-def get_localizations(key: str) -> dict:
-    """Return mapping of locale->translation for the given key.
-
-    Falls back to English if a specific locale does not provide the key.
-    """
-    localizations = {}
-    for path in LOCALE_DIR.glob('*.json'):
-        locale = path.stem
-        value = _lookup(locale, key)
-        if value:
-            localizations[locale] = value
-    if 'en' not in localizations:
-        value = _lookup('en', key)
-        if value:
-            localizations['en'] = value
-    return localizations
+def tr(ctx, key: str, **kwargs) -> str:
+    """Translate *key* using the locale derived from *ctx*."""
+    return t(key, get_locale(ctx), **kwargs)
 
 
 def cmd(key: str) -> dict:
-    """Return parameters for a localized command/group."""
-    name_loc = get_localizations(f'commands.{key}.name')
-    desc_loc = get_localizations(f'commands.{key}.description')
-    return dict(
-        name=name_loc.get('en', key.split('.')[-1]),
-        description=desc_loc.get('en', ''),
-        name_localizations=name_loc,
-        description_localizations=desc_loc,
-    )
+    """Return English name/description for a command or group."""
+    name = t(f'commands.{key}.name', 'en')
+    desc = t(f'commands.{key}.description', 'en')
+    if name == f'commands.{key}.name':
+        name = key.split('.')[-1]
+    if desc == f'commands.{key}.description':
+        desc = ''
+    return dict(name=name, description=desc)
 
 
-def option(command_key: str, option_name: str, default=None):
-    """Return app_commands.Param configured with localizations."""
-    name_loc = get_localizations(f'commands.{command_key}.options.{option_name}.name')
-    desc_loc = get_localizations(f'commands.{command_key}.options.{option_name}.description')
-    return app_commands.Param(
-        default,
-        name=name_loc.get('en', option_name),
-        description=desc_loc.get('en', ''),
-        name_localizations=name_loc,
-        description_localizations=desc_loc,
-    )
+def option(command_key: str, option_name: str) -> str:
+    """Return the English description for an option.
+
+    This pulls the description from the locale JSON files so descriptions
+    remain centralized alongside other translations. Only the English strings
+    are used for command registration in accordance with discord.py 2.5.2.
+    """
+
+    desc = t(f'commands.{command_key}.options.{option_name}.description', 'en')
+    if desc == f'commands.{command_key}.options.{option_name}.description':
+        desc = ''
+    return desc
+


### PR DESCRIPTION
## Summary
- drop `name_localizations`/`description_localizations` usage and rely on JSON-based i18n
- add `tr` helper for context-aware translations
- update cogs to use new helper and English-only command metadata
- fix option helper to work with discord.py 2.5.2 and describe parameters via JSON strings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893b139b3d4832598f683b183ebf534