### PR TITLE
Localize DM embeds and add order translations

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -222,6 +222,18 @@
         "in_progress": "In Progress",
         "cancelled": "Cancelled"
       }
+    },
+    "embed": {
+      "items_sold_to": "Items Sold to {buyer}",
+      "discord_user_details": "Discord User Details",
+      "complete_delivery": "Complete the delivery of sold items to {buyer}",
+      "total": "Total",
+      "user_offer": "User Offer",
+      "note_from_buyer": "Note from buyer",
+      "offer": "Offer",
+      "kind": "Kind",
+      "collateral": "Collateral",
+      "today": "Today at {time}"
     }
   },
   "registration": {

--- a/locale/uk.json
+++ b/locale/uk.json
@@ -222,6 +222,18 @@
         "in_progress": "В процесі",
         "cancelled": "Скасовано"
       }
+    },
+    "embed": {
+      "items_sold_to": "Товари продані для {buyer}",
+      "discord_user_details": "Деталі користувача Discord",
+      "complete_delivery": "Завершіть доставку проданих товарів для {buyer}",
+      "total": "Разом",
+      "user_offer": "Пропозиція користувача",
+      "note_from_buyer": "Повідомлення від покупця",
+      "offer": "Пропозиція",
+      "kind": "Тип",
+      "collateral": "Застава",
+      "today": "Сьогодні о {time}"
     }
   },
   "registration": {


### PR DESCRIPTION
## Summary
- localize order status DM embeds and invitation messages
- add English and Ukrainian translation keys for order DM fields

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893c71f340883259f05140c6de8eb16