### PR TITLE
Load dotenv and drop unsupported localizations

### DIFF
--- a/cogs/lookup.py
+++ b/cogs/lookup.py
@@ -21,7 +21,6 @@ class Lookup(commands.Cog):
             app_commands.Choice(
                 name=t(f"categories.{item}", 'en'),
                 value=item,
-                name_localizations={'uk': t(f"categories.{item}", 'uk')},
             )
             for item in categories
         ],
@@ -29,7 +28,6 @@ class Lookup(commands.Cog):
             app_commands.Choice(
                 name=t(value, 'en'),
                 value=key,
-                name_localizations={'uk': t(value, 'uk')},
             )
             for key, value in sorting_methods.items()
         ],
@@ -37,7 +35,6 @@ class Lookup(commands.Cog):
             app_commands.Choice(
                 name=t(f"sale_types.{item}", 'en'),
                 value=item,
-                name_localizations={'uk': t(f"sale_types.{item}", 'uk')},
             )
             for item in sale_types
         ],

--- a/cogs/order.py
+++ b/cogs/order.py
@@ -22,17 +22,14 @@ class order(commands.GroupCog):
             app_commands.Choice(
                 name=t('order.status.choices.fulfilled', 'en'),
                 value='fulfilled',
-                name_localizations={'uk': t('order.status.choices.fulfilled', 'uk')},
             ),
             app_commands.Choice(
                 name=t('order.status.choices.in_progress', 'en'),
                 value='in-progress',
-                name_localizations={'uk': t('order.status.choices.in_progress', 'uk')},
             ),
             app_commands.Choice(
                 name=t('order.status.choices.cancelled', 'en'),
                 value='cancelled',
-                name_localizations={'uk': t('order.status.choices.cancelled', 'uk')},
             ),
         ],
     )

--- a/main.py
+++ b/main.py
@@ -16,6 +16,9 @@ from cogs.stock import stock
 from util.api_server import create_api
 from util.result import Result
 from util.i18n import t, tr
+from dotenv import load_dotenv
+
+load_dotenv()
 
 intents = discord.Intents.default()
 intents.members = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ discord.py
 aiohttp
 humanize
 ujson
+python-dotenv
 pytest


### PR DESCRIPTION
## Summary
- load environment variables from `.env`
- remove unsupported `name_localizations` options from commands
- add python-dotenv dependency

## Testing
- `pip install -r requirements.txt` *(fails: fatal: unable to access 'https://github.com/Soheab/discord-py-paginators.git/')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893cab486b8832582a1817ada7e5ec2