### PR TITLE
Remove localization args and load dotenv early

### DIFF
--- a/cogs/order.py
+++ b/cogs/order.py
@@ -13,7 +13,7 @@ from util.i18n import tr, cmd, option, t
 
 class order(commands.GroupCog):
     def __init__(self, bot):
-        super().__init__(**cmd('order'))
+        super().__init__()
         self.bot = bot
 
     @app_commands.command(**cmd('order.status'))

--- a/cogs/registration.py
+++ b/cogs/registration.py
@@ -17,7 +17,7 @@ class Registration(commands.GroupCog):
     server = app_commands.Group(**cmd('register.server'))
 
     def __init__(self, bot):
-        super().__init__(**cmd('register'))
+        super().__init__()
         self.bot = bot
 
     async def cog_app_command_error(self, interaction: discord.Interaction, error):

--- a/cogs/stock.py
+++ b/cogs/stock.py
@@ -14,7 +14,7 @@ from util.i18n import tr, cmd, option
 
 class stock(commands.GroupCog):
     def __init__(self, bot):
-        super().__init__(**cmd('stock'))
+        super().__init__()
         self.bot = bot
 
     @app_commands.command(**cmd('stock.set'))

--- a/main.py
+++ b/main.py
@@ -2,6 +2,10 @@ import logging
 import os
 import traceback
 
+from dotenv import load_dotenv
+
+load_dotenv()
+
 import aiohttp
 import discord
 from aiohttp import web
@@ -16,9 +20,6 @@ from cogs.stock import stock
 from util.api_server import create_api
 from util.result import Result
 from util.i18n import t, tr
-from dotenv import load_dotenv
-
-load_dotenv()
 
 intents = discord.Intents.default()
 intents.members = True


### PR DESCRIPTION
## Summary
- call `load_dotenv()` before importing modules that use environment variables
- drop localization arguments from GroupCog initializers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d0f717e88325817f60478b696341