### PR TITLE
Localize DM embed fields

### DIFF
--- a/locale/en.json
+++ b/locale/en.json
@@ -227,6 +227,8 @@
       "items_sold_to": "Items Sold to {buyer}",
       "discord_user_details": "Discord User Details",
       "complete_delivery": "Complete the delivery of sold items to {buyer}",
+      "item_field": "{item}",
+      "item_quantity": "Quantity: {quantity}",
       "total": "Total",
       "user_offer": "User Offer",
       "note_from_buyer": "Note from buyer",

--- a/locale/uk.json
+++ b/locale/uk.json
@@ -227,6 +227,8 @@
       "items_sold_to": "Товари продані для {buyer}",
       "discord_user_details": "Деталі користувача Discord",
       "complete_delivery": "Завершіть доставку проданих товарів для {buyer}",
+      "item_field": "{item}",
+      "item_quantity": "Кількість: {quantity}",
       "total": "Разом",
       "user_offer": "Пропозиція користувача",
       "note_from_buyer": "Повідомлення від покупця",

--- a/main.py
+++ b/main.py
@@ -184,7 +184,11 @@ class SCMarket(Bot):
                 inline=False,
             )
             for item in order.get('items', []):
-                embed.add_field(name=item.get('name'), value=str(item.get('quantity', '')), inline=False)
+                embed.add_field(
+                    name=tr(user, 'order.embed.item_field', item=item.get('name')),
+                    value=tr(user, 'order.embed.item_quantity', quantity=str(item.get('quantity', ''))),
+                    inline=False,
+                )
             if order.get('total') is not None:
                 embed.add_field(name=tr(user, 'order.embed.total'), value=str(order.get('total')), inline=True)
             if order.get('user_offer') is not None:


### PR DESCRIPTION
## Summary
- localize item fields in DM order status embed
- add translation keys for item name and quantity in en/uk locale files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893daa3b5cc83259215d2eec27073c9