### PR TITLE
Localize paginator controls and item types

### DIFF
--- a/cogs/lookup.py
+++ b/cogs/lookup.py
@@ -3,7 +3,7 @@ from typing import List
 import discord
 from discord import app_commands
 from discord.ext import commands
-from discord.ext.paginators.button_paginator import ButtonPaginator
+from util.paginator import LocalizedPaginator
 
 from util.fetch import public_fetch, search_users, search_orgs
 from util.listings import create_market_embed, categories, sorting_methods, sale_types, create_market_embed_individual, \
@@ -89,7 +89,7 @@ class Lookup(commands.Cog):
             await interaction.response.send_message(tr(interaction, 'search.no_results'))
             return
 
-        paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
+        paginator = LocalizedPaginator(embeds, locale, author_id=interaction.user.id)
         await paginator.send(interaction)
 
     lookup = app_commands.Group(**cmd('lookup'))
@@ -128,7 +128,7 @@ class Lookup(commands.Cog):
                 await interaction.response.send_message(tr(interaction, 'lookup.no_listings'))
                 return
 
-            paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
+            paginator = LocalizedPaginator(embeds, locale, author_id=interaction.user.id)
             await paginator.send(interaction)
 
     @lookup.command(**cmd('lookup.org'))
@@ -165,7 +165,7 @@ class Lookup(commands.Cog):
                 await interaction.response.send_message(tr(interaction, 'lookup.no_org_listings'))
                 return
 
-            paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
+            paginator = LocalizedPaginator(embeds, locale, author_id=interaction.user.id)
             await paginator.send(interaction)
 
     @user_search.autocomplete('handle')

--- a/locale/en.json
+++ b/locale/en.json
@@ -274,7 +274,8 @@
     "flair": "Flair",
     "addon": "Addon",
     "consumable": "Consumable",
-    "other": "Other"
+    "other": "Other",
+    "quantum drive": "Quantum Drive"
   },
   "sorting": {
     "title": "Title",
@@ -291,6 +292,15 @@
     "aggregate": "Aggregate",
     "auction": "Auction",
     "sale": "Sale"
+  },
+  "paginator": {
+    "first": "First",
+    "left": "Left",
+    "page": "Page {page} of {total}",
+    "right": "Right",
+    "last": "Last",
+    "stop": "Stop",
+    "action_failed": "Action failed"
   },
   "views": {
     "select_status": "Select status...",

--- a/locale/uk.json
+++ b/locale/uk.json
@@ -274,7 +274,8 @@
     "flair": "Флейр",
     "addon": "Аддон",
     "consumable": "Витратник",
-    "other": "Інше"
+    "other": "Інше",
+    "quantum drive": "Квантовий двигун"
   },
   "sorting": {
     "title": "Назва",
@@ -291,6 +292,15 @@
     "aggregate": "Пакет",
     "auction": "Аукціон",
     "sale": "Продаж"
+  },
+  "paginator": {
+    "first": "Перша",
+    "left": "Ліва",
+    "page": "Сторінка {page} з {total}",
+    "right": "Права",
+    "last": "Остання",
+    "stop": "Зупинити",
+    "action_failed": "Дія не вдалася"
   },
   "views": {
     "select_status": "Виберіть статус...",

--- a/util/listings.py
+++ b/util/listings.py
@@ -3,7 +3,8 @@ from typing import List
 
 import discord
 import humanize
-from discord.ext.paginators.button_paginator import ButtonPaginator
+
+from util.paginator import LocalizedPaginator
 
 from util.iter import chunks
 from util.i18n import t, get_locale, tr
@@ -37,11 +38,17 @@ sorting_methods = {
 sale_types = ["aggregate", "auction", "sale"]
 
 
+def _item_type_name(item_type: str, locale: str) -> str:
+    key = f"categories.{item_type.lower()}"
+    translated = t(key, locale)
+    return item_type if translated == key else translated
+
+
 def create_market_embed(listing: dict, locale: str):
     embed = discord.Embed(url=f"https://sc-market.space/market/{listing['listing_id']}", title=listing['title'])
     embed.add_field(
         name=t('fields.item_type', locale),
-        value=t(f"categories.{listing['item_type'].lower()}", locale),
+        value=_item_type_name(listing['item_type'], locale),
     )
     if listing["listing_type"] != "unique":
         embed.add_field(name=t('fields.minimum_price', locale), value=f"{int(listing['minimum_price']):,} aUEC")
@@ -73,7 +80,7 @@ def create_market_embed_individual(listing: dict, locale: str):
                           title=listing['details']['title'])
     embed.add_field(
         name=t('fields.item_type', locale),
-        value=t(f"categories.{listing['details']['item_type'].lower()}", locale),
+        value=_item_type_name(listing['details']['item_type'], locale),
     )
     embed.add_field(name=t('fields.price', locale), value=f"{int(listing['listing']['price']):,} aUEC")
     seller = listing['listing'].get('contractor_seller') or listing['listing'].get('user_seller')
@@ -139,5 +146,5 @@ async def display_listings_compact(interaction: discord.Interaction, alllistings
         await interaction.response.send_message(tr(interaction, empty_key))
         return
 
-    paginator = ButtonPaginator(embeds, author_id=interaction.user.id)
+    paginator = LocalizedPaginator(embeds, locale, author_id=interaction.user.id)
     await paginator.send(interaction)

--- a/util/paginator.py
+++ b/util/paginator.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from typing import Sequence
+
+import discord
+from discord.ext.paginators.button_paginator import ButtonPaginator, PaginatorButton
+
+from util.i18n import t
+
+
+class LocalizedPaginator(ButtonPaginator):
+    """Button paginator with localized labels and messages."""
+
+    def __init__(self, pages: Sequence, locale: str, *, author_id: int | None = None, **kwargs) -> None:
+        self.locale = locale
+        buttons = {
+            "FIRST": PaginatorButton(label=t('paginator.first', locale), position=0),
+            "LEFT": PaginatorButton(label=t('paginator.left', locale), position=1),
+            "PAGE_INDICATOR": PaginatorButton(label="", position=2, disabled=False),
+            "RIGHT": PaginatorButton(label=t('paginator.right', locale), position=3),
+            "LAST": PaginatorButton(label=t('paginator.last', locale), position=4),
+            "STOP": PaginatorButton(label=t('paginator.stop', locale), style=discord.ButtonStyle.danger, position=5),
+        }
+        super().__init__(pages, buttons=buttons, author_id=author_id, **kwargs)
+
+    @property
+    def page_string(self) -> str:  # type: ignore[override]
+        return t('paginator.page', self.locale, page=self.current_page + 1, total=self.max_pages)
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:  # type: ignore[override]
+        valid = await super().interaction_check(interaction)
+        if not valid and not interaction.response.is_done():
+            await interaction.response.send_message(t('paginator.action_failed', self.locale), ephemeral=True)
+        return valid


### PR DESCRIPTION
## Summary
- localize paginator buttons and page indicator via new `LocalizedPaginator`
- translate item type names and add Quantum Drive category
- show fallback English item type when translation missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689491bc31b48325b0be1771ec18a7c0